### PR TITLE
Fix diffs of files that have quoted paths

### DIFF
--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -129,8 +129,8 @@ module Git
         final = {}
         current_file = nil
         @full_diff.split("\n").each do |line|
-          if m = /^diff --git a\/(.*?) b\/(.*?)/.match(line)
-            current_file = m[1]
+          if m = %r{\Adiff --git ("?)a/(.+?)\1 \1b/(.+?)\1\z}.match(line)
+            current_file = m[2]
             final[current_file] = defaults.merge({:patch => line, :path => current_file})
           else
             if m = /^index ([0-9a-f]{4,40})\.\.([0-9a-f]{4,40})( ......)*/.match(line)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1067,7 +1067,8 @@ module Git
       global_opts = []
       global_opts << "--git-dir=#{@git_dir}" if !@git_dir.nil?
       global_opts << "--work-tree=#{@git_work_dir}" if !@git_work_dir.nil?
-      global_opts << ["-c", "color.ui=false"]
+      global_opts << %w[-c core.quotePath=false]
+      global_opts << %w[-c color.ui=false]
 
       opts = [opts].flatten.map {|s| escape(s) }.join(' ')
 

--- a/tests/units/test_diff_with_quoted_path.rb
+++ b/tests/units/test_diff_with_quoted_path.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require File.dirname(__FILE__) + '/../test_helper'
+
+# Test diff when the file path has to be quoted according to core.quotePath
+# See https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
+#
+class TestDiffWithQuotedPath < Test::Unit::TestCase
+  def test_diff_with_non_ascii_filename
+    in_temp_dir do |path|
+      create_file('my_other_file_☠', "First Line\n")
+      `git init`
+      `git add .`
+      `git commit -m 'First Commit'`
+      update_file('my_other_file_☠', "Second Line\n")
+      diff_paths = Git.open('.').diff.map(&:path)
+      assert_equal(diff_paths, ['my_other_file_☠'])
+    end
+  end
+end

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -7,32 +7,49 @@ class TestLogger < Test::Unit::TestCase
   def setup
     set_file_paths
   end
-  
+
+  def missing_log_entry
+    'Did not find expected log entry.'
+  end
+
+  def unexpected_log_entry
+    'Unexpected log entry found'
+  end
+
   def test_logger
     log = Tempfile.new('logfile')
     log.close
-    
+
     logger = Logger.new(log.path)
     logger.level = Logger::DEBUG
-    
+
     @git = Git.open(@wdir, :log => logger)
     @git.branches.size
-    
-    logc = File.read(log.path)
-    assert(/INFO -- : git ['"]--git-dir=[^'"]+['"] ['"]--work-tree=[^'"]+['"] ['"]-c['"] ['"]color.ui=false['"] branch ['"]-a['"]/.match(logc))
-    assert(/DEBUG -- :   cherry\n  diff_over_patches\n\* git_grep/m.match(logc))
 
+    logc = File.read(log.path)
+
+    expected_log_entry = /INFO -- : git (?<global_options>.*?) branch ['"]-a['"]/
+    assert_match(expected_log_entry, logc, missing_log_entry)
+
+    expected_log_entry = /DEBUG -- :   cherry/
+    assert_match(expected_log_entry, logc, missing_log_entry)
+  end
+
+  def test_logging_at_info_level_should_not_show_debug_messages
     log = Tempfile.new('logfile')
     log.close
     logger = Logger.new(log.path)
     logger.level = Logger::INFO
-    
+
     @git = Git.open(@wdir, :log => logger)
     @git.branches.size
-    
+
     logc = File.read(log.path)
-    assert(/INFO -- : git ['"]--git-dir=[^'"]+['"] ['"]--work-tree=[^'"]+['"] ['"]-c['"] ['"]color.ui=false['"] branch ['"]-a['"]/.match(logc))
-    assert(!/DEBUG -- :   cherry\n  diff_over_patches\n\* git_grep/m.match(logc))
+
+    expected_log_entry = /INFO -- : git (?<global_options>.*?) branch ['"]-a['"]/
+    assert_match(expected_log_entry, logc, missing_log_entry)
+
+    expected_log_entry = /DEBUG -- :   cherry/
+    assert_not_match(expected_log_entry, logc, unexpected_log_entry)
   end
-  
 end


### PR DESCRIPTION
backup for https://github.com/ruby-git/ruby-git/pull/504

The branch is force-pushed at https://github.com/ruby-git/ruby-git/pull/504#event-5795597110, and this branch is snapshot from before force-pushed.